### PR TITLE
[W-10592639] add license headers

### DIFF
--- a/mulesoft/Accessibility.yml
+++ b/mulesoft/Accessibility.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "Don't use language (such as '%s') that are not accessible."
 link: https://confluence.internal.salesforce.com/display/MTDT/MuleSoft+CX+Writing+Style+Reference

--- a/mulesoft/Avoid.yml
+++ b/mulesoft/Avoid.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "Don't use '%s'. See the Writing Style Reference for details."
 link: https://confluence.internal.salesforce.com/display/MTDT/MuleSoft+CX+Writing+Style+Reference

--- a/mulesoft/Collocations.yml
+++ b/mulesoft/Collocations.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "Don't use collocation words such as '%s'. See the Writing Style Reference for details."
 # See the Writing Style Reference

--- a/mulesoft/Foreign.yml
+++ b/mulesoft/Foreign.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: substitution
 message: "Use '%s' instead of '%s'."
 link: https://docs.microsoft.com/en-us/style-guide/word-choice/use-us-spelling-avoid-non-english-words

--- a/mulesoft/GenderBias.yml
+++ b/mulesoft/GenderBias.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: substitution
 message: "Consider using '%s' instead of '%s'."
 ignorecase: true

--- a/mulesoft/GeneralURL.yml
+++ b/mulesoft/GeneralURL.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "For a general audience, use 'address' rather than 'URL'."
 link: https://docs.microsoft.com/en-us/style-guide/urls-web-addresses

--- a/mulesoft/HeadingColons.yml
+++ b/mulesoft/HeadingColons.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "Capitalize '%s'."
 link: https://docs.microsoft.com/en-us/style-guide/punctuation/colons

--- a/mulesoft/InclusiveProductLanguage.yml
+++ b/mulesoft/InclusiveProductLanguage.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: substitution
 message: "Consider using '%s' instead of '%s'."
 link: https://salesforce.quip.com/bUe4AltWVElW#YKFACA3U5fz

--- a/mulesoft/Ordinal.yml
+++ b/mulesoft/Ordinal.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "Don't add -ly to an ordinal number."
 link: https://docs.microsoft.com/en-us/style-guide/numbers

--- a/mulesoft/OxfordComma.yml
+++ b/mulesoft/OxfordComma.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "Use the Oxford comma in '%s'."
 link: https://docs.microsoft.com/en-us/style-guide/punctuation/commas

--- a/mulesoft/Passive.yml
+++ b/mulesoft/Passive.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "'%s' looks like passive voice."
 ignorecase: true

--- a/mulesoft/Pronouns.yml
+++ b/mulesoft/Pronouns.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "Do not use gender-specific languages like '%s'."
 link: https://github.com/MicrosoftDocs/microsoft-style-guide/blob/master/styleguide/grammar/nouns-pronouns.md#pronouns-and-gender

--- a/mulesoft/Spacing.yml
+++ b/mulesoft/Spacing.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "'%s' should have one space."
 link: https://docs.microsoft.com/en-us/style-guide/punctuation/periods

--- a/mulesoft/Symbols.yml
+++ b/mulesoft/Symbols.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: existence
 message: "Do not use symbols like '%s'. See the Writing Style Reference for details."
 link: https://confluence.internal.salesforce.com/display/MTDT/MuleSoft+CX+Writing+Style+Reference

--- a/mulesoft/Terms.yml
+++ b/mulesoft/Terms.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 extends: substitution
 message: "Prefer '%s' over '%s'."
 link: https://confluence.internal.salesforce.com/display/MTDT/MuleSoft+CX+Writing+Style+Reference

--- a/valkyr.yaml
+++ b/valkyr.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2022, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 product: dev-docs
 component: writing-style
 strategy: docker


### PR DESCRIPTION
ref: W-10592639

add license headers to all non-example yaml files. Based on instructions from https://github.com/mulesoft/dev-docs-writing-style/blob/master/license_info.md