### PR TITLE
[W-13140903] fix vale error + add testing stage

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+StylesPath = .
+MinAlertLevel = suggestion
+
+[*.adoc]
+BasedOnStyles = Accessibility, Writing

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,6 @@
+FROM jdkato/vale:v2.25.2
+
+WORKDIR /usr/src/app
+COPY MuleSoft .
+COPY .vale.ini .
+RUN vale

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,17 @@ def githubCredentialsId = 'GH_TOKEN'
 pipeline {
   agent any
   stages {
+    stage('Test') {
+      when {
+        allOf {
+          not { branch defaultBranch }
+          changeset "MuleSoft/**"
+        }
+      }
+      steps {
+        sh "docker build -f Dockerfile.test ."
+      }
+    }
     stage('Release') {
       when {
         allOf {

--- a/MuleSoft/Writing/HeadingCapitalization.yml
+++ b/MuleSoft/Writing/HeadingCapitalization.yml
@@ -7,7 +7,6 @@
 #
 extends: capitalization
 message: "Use title-style capitalization in headings"
-nonword: true
 level: warning
 scope: heading
 match: $title


### PR DESCRIPTION
ref: W-13140903

- remove nonword key from HeadingCapitalization. Per [vale doc on capitalization](https://vale.sh/docs/topics/styles/#capitalization), the key is not applicable and new vale versions error out
- add a stage to test the rules before merging. This saves time to manually test