### PR TITLE
WIP [W-13186275] new vale rules - Redundant use of Anypoint in product names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM artifacts.msap.io/mulesoft/core-paas-base-image-node-16:v4.7.29 as BUILD
+FROM artifacts.msap.io/mulesoft/core-paas-base-image-node-18:v4.7.29 AS BUILD
 
 ENV FIPS_ENABLED=false
 

--- a/MuleSoft/Writing/PrecededByAnypoint.yml
+++ b/MuleSoft/Writing/PrecededByAnypoint.yml
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clausescope: raw
 #
-# Flags occurrences in which there is more than one space between sentences
 #
 extends: occurrence
 message: |

--- a/MuleSoft/Writing/Redundant.yml
+++ b/MuleSoft/Writing/Redundant.yml
@@ -13,4 +13,4 @@ level: error
 scope: sentence
 ignorecase: false
 max: 1
-token: '(?:Anypoint) \b((Studio)|(Test))\b'
+token: '(?:Anypoint) (Studio|Test)\b'

--- a/MuleSoft/Writing/Redundant.yml
+++ b/MuleSoft/Writing/Redundant.yml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023, salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clausescope: raw
+#
+# Flags occurrences in which there is more than one space between sentences
+#
+extends: occurrence
+message: |
+  "Only use 'Anypoint <your product>' in its first occurrence, and then simply '<your product>' thereafter.
+  For example, after you have used 'Anypoint Studio' once, refer to it as 'Studio' afterwards."
+level: error
+scope: sentence
+ignorecase: false
+max: 1
+token: '(?:Anypoint) \b((Studio)|(Test))\b'


### PR DESCRIPTION
ref: W-13186275

- upgrade node 16 -> 18
- add vale rule to cap the maximum occurrence of `Anypoint <product name>` to 1 per page. This is a simplified way to ensure that `Anypoint <product name>` is only used once and the other references on the page will be simply `<product name>`.