### PR TITLE
Remove space after "a a"

### DIFF
--- a/MuleSoft/Writing/CommonMispellings.yml
+++ b/MuleSoft/Writing/CommonMispellings.yml
@@ -17,5 +17,5 @@ swap:
   'that that': that
   'the the': the
   'to to': to
-  'a a ': a
+  'a a': a
   'an an': an


### PR DESCRIPTION
Matching "a a " and substituting a single "a" with no space was applying an incorrect fix